### PR TITLE
🔒 Secure /ingest endpoint with auth and add rate limiting to /ask

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,12 @@ function json(data, status = 200) {
 
 // POST /ingest  — teach the assistant a document
 async function handleIngest(request, env) {
+  const authHeader = request.headers.get("Authorization");
+  const expectedToken = env.INGEST_TOKEN;
+  if (!expectedToken || authHeader !== `Bearer ${expectedToken}`) {
+    return json({ error: "Unauthorized. Provide a valid 'Authorization: Bearer <token>' header." }, 401);
+  }
+
   const { text, source = "manual" } = await request.json().catch(() => ({}));
   if (!text) return json({ error: "Missing 'text' in body." }, 400);
 
@@ -55,6 +61,14 @@ async function handleIngest(request, env) {
 
 // POST /ask  — answer a question grounded ONLY in the ingested documents
 async function handleAsk(request, env) {
+  if (env.RATE_LIMITER) {
+    const ip = request.headers.get("cf-connecting-ip") || "anonymous";
+    const { success } = await env.RATE_LIMITER.limit({ key: ip });
+    if (!success) {
+      return json({ error: "Rate limit exceeded. Please try again later." }, 429);
+    }
+  }
+
   const { question, topK = 5 } = await request.json().catch(() => ({}));
   if (!question) return json({ error: "Missing 'question' in body." }, 400);
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -13,6 +13,15 @@
   // Binding a la base vectorial (Vectorize) → env.VECTORIZE
   "vectorize": [
     { "binding": "VECTORIZE", "index_name": "rag-index" }
+  ],
+
+  // Rate limiting binding para proteger /ask
+  "rate_limiting": [
+    {
+      "binding": "RATE_LIMITER",
+      "namespace_id": "1001",
+      "simple": { "limit": 10, "period": 60 }
+    }
   ]
 
   // (Más adelante agregamos R2 aquí para guardar los documentos originales.)


### PR DESCRIPTION
Este PR implementa medidas de seguridad críticas para la demo pública:
- Protege `POST /ingest` exigiendo un token secreto en el header `Authorization: Bearer` validado contra `env.INGEST_TOKEN`.
- Añade rate limiting por IP (`cf-connecting-ip`) al endpoint `POST /ask` usando un binding de Workers Rate Limiting.
- Actualiza la documentación (`README.md` y `README.es.md`) indicando el uso de `wrangler secret put INGEST_TOKEN`.

Cierra #1

Closes #1