### PR TITLE
🔒 Secure /ingest with Bearer token and add rate limiting to /ask

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,12 @@ function json(data, status = 200) {
 
 // POST /ingest  — teach the assistant a document
 async function handleIngest(request, env) {
+  const authHeader = request.headers.get("Authorization");
+  const expectedToken = env.INGEST_TOKEN;
+  if (!expectedToken || authHeader !== `Bearer ${expectedToken}`) {
+    return json({ error: "Unauthorized. Provide a valid 'Authorization: Bearer <token>' header." }, 401);
+  }
+
   const { text, source = "manual" } = await request.json().catch(() => ({}));
   if (!text) return json({ error: "Missing 'text' in body." }, 400);
 
@@ -55,6 +61,14 @@ async function handleIngest(request, env) {
 
 // POST /ask  — answer a question grounded ONLY in the ingested documents
 async function handleAsk(request, env) {
+  if (env.RATE_LIMITER) {
+    const ip = request.headers.get("cf-connecting-ip") || "unknown";
+    const { success } = await env.RATE_LIMITER.limit({ key: ip });
+    if (!success) {
+      return json({ error: "Rate limit exceeded. Please try again later." }, 429);
+    }
+  }
+
   const { question, topK = 5 } = await request.json().catch(() => ({}));
   if (!question) return json({ error: "Missing 'question' in body." }, 400);
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -13,7 +13,14 @@
   // Binding a la base vectorial (Vectorize) → env.VECTORIZE
   "vectorize": [
     { "binding": "VECTORIZE", "index_name": "rag-index" }
-  ]
+  ],
 
-  // (Más adelante agregamos R2 aquí para guardar los documentos originales.)
+  // Binding a Rate Limiting → env.RATE_LIMITER
+  "ratelimits": [
+    {
+      "binding": "RATE_LIMITER",
+      "namespace_id": "1001",
+      "simple": { "limit": 10, "period": 60 }
+    }
+  ]
 }


### PR DESCRIPTION
What changes:
- Adds `Authorization: Bearer <token>` check to `POST /ingest` matching `env.INGEST_TOKEN`.
- Adds a Cloudflare Workers Rate Limiting binding to `wrangler.jsonc` and enforces it on `POST /ask` using `cf-connecting-ip` as key.
- Updates documentation in `README.md` and `README.es.md` regarding the new ingest authentication and how to set the secret.

Why:
- Prevents data poisoning on Vectorize by locking down write operations (`/ingest`).
- Mitigates denial-of-wallet / cost abuse on AI models by rate-limiting public queries (`/ask`).

Closes #1

Closes #1