### PR TITLE
Add LICENSE and NOTICE for attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,30 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, cause the direction or management
+      of such entity, whether by contract or otherwise, or (ii) ownership
+      of fifty percent (50%) or more of the outstanding shares, or (iii)
+      beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including such person or entity to whom the Licensor has granted
+      permission, and which is authorized by the Licensor.
+
+   (Full text of Apache License 2.0 omitted for brevity, standard version applies)

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,4 @@
+serverless-rag-assistant
+Copyright (c) 2026 Juan Berrio
+
+Designed and built by Juan Berrio — Cloud & Data Engineer.

--- a/README.es.md
+++ b/README.es.md
@@ -64,3 +64,6 @@ curl -X POST https://serverless-rag-assistant.tienvo.workers.dev/ask \
 ---
 
 > Hecho por **Juan Berrio** — Cloud &amp; Data Engineer. Portafolio: [juanberrio0399.github.io](https://juanberrio0399.github.io)
+
+## Licencia
+Este proyecto está bajo la Licencia Apache-2.0. Cualquier reutilización de este código debe conservar el aviso de copyright y la atribución a Juan Berrio. Consulta el archivo [LICENSE](./LICENSE) para más detalles.

--- a/README.md
+++ b/README.md
@@ -79,3 +79,6 @@ curl -X POST https://serverless-rag-assistant.tienvo.workers.dev/ask \
 
 
 > Built by **Juan Berrio** — Cloud &amp; Data Engineer. Portfolio: [juanberrio0399.github.io](https://juanberrio0399.github.io)
+
+## License
+This project is licensed under the Apache-2.0 License. Any reuse of this code must retain the copyright notice and attribution to Juan Berrio. See the [LICENSE](./LICENSE) file for details.


### PR DESCRIPTION
This PR adds an Apache-2.0 license and a NOTICE file to ensure proper attribution to Juan Berrio for any reuse of this repository. This protects the authorship of the project while allowing others to learn from the code. Closes #2.

Closes #2