### PR TITLE
Demo visual en el navegador: UI con ingest + scores (issue #11)

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -41,12 +41,24 @@ Docs →  trozos → embeddings → Vectorize   |  pregunta → embedding → Ve
 
 ## Demo en vivo
 
-🟢 **En vivo:** https://serverless-rag-assistant.tienvo.workers.dev
+🟢 **Pruébalo en el navegador — sin terminal:** https://serverless-rag-assistant.tienvo.workers.dev
+
+El propio Worker sirve una pequeña **interfaz web** (HTML/JS vanilla, sin build): eliges una pregunta de ejemplo, pulsas **Obtener respuesta** y ves la respuesta fundamentada **con su documento fuente y los puntajes de similitud** en un clic. Un panel *Avanzado* permite ingerir tu propio documento (protegido por token — tú lo pegas, nada se guarda en la página).
+
+![Serverless RAG Assistant — demo en el navegador: preguntar y obtener una respuesta fundamentada con fuentes y puntajes de similitud](docs/demo.gif)
+
+<!-- El GIF de arriba se graba aparte (el binario no se incluye en este cambio de código). Ver docs/DEMO.md para el guion de grabación de ~20s. Hasta que se agregue, el enlace de la imagen estará roto — es lo esperado en esta rama. -->
+
+> *Grabación del GIF pendiente — ver [`docs/DEMO.md`](docs/DEMO.md) para el flujo exacto ingerir → preguntar → respuesta a capturar.*
+
+<details>
+<summary><b>¿Prefieres la terminal?</b> Lo mismo con <code>curl</code> (referencia secundaria)</summary>
 
 ```bash
-# 1) Enseñarle un documento
+# 1) Enseñarle un documento  (la ingesta está protegida por token)
 curl -X POST https://serverless-rag-assistant.tienvo.workers.dev/ingest \
   -H "content-type: application/json" \
+  -H "authorization: Bearer <TU_INGEST_TOKEN>" \
   -d '{"text":"El texto de tu documento aquí...","source":"mi-doc"}'
 
 # 2) Preguntar (con base en tus documentos — espera ~10s tras ingerir)
@@ -54,6 +66,8 @@ curl -X POST https://serverless-rag-assistant.tienvo.workers.dev/ask \
   -H "content-type: application/json" \
   -d '{"question":"..."}'
 ```
+
+</details>
 
 **Puntos clave:**
 - **Anti-alucinación** — responde "no sé" cuando la respuesta no está en tus documentos (guardarraíl por prompt engineering).

--- a/README.md
+++ b/README.md
@@ -53,12 +53,24 @@ Docs →  chunk → embeddings → Vectorize   |  question → embedding → Vec
 
 ## Live demo
 
-🟢 **Live:** https://serverless-rag-assistant.tienvo.workers.dev
+🟢 **Try it in your browser — no terminal needed:** https://serverless-rag-assistant.tienvo.workers.dev
+
+The Worker itself serves a small **web UI** (vanilla HTML/JS, no build step): pick an example question, hit **Get answer**, and see the grounded response **with its source document and similarity scores** in one click. An *Advanced* panel lets you ingest your own document (token-protected — you paste the token, nothing is stored in the page).
+
+![Serverless RAG Assistant — browser demo: ask a question, get a grounded answer with sources and similarity scores](docs/demo.gif)
+
+<!-- The GIF above is recorded separately (binary not committed by the code change). See docs/DEMO.md for the 20-second recording script. Until it is added the image link will be broken — that is expected on this branch. -->
+
+> *GIF recording pending — see [`docs/DEMO.md`](docs/DEMO.md) for the exact ingest → ask → answer flow to capture.*
+
+<details>
+<summary><b>Prefer the terminal?</b> Same thing with <code>curl</code> (secondary reference)</summary>
 
 ```bash
-# 1) Teach it a document
+# 1) Teach it a document  (ingest is token-protected)
 curl -X POST https://serverless-rag-assistant.tienvo.workers.dev/ingest \
   -H "content-type: application/json" \
+  -H "authorization: Bearer <YOUR_INGEST_TOKEN>" \
   -d '{"text":"Your document text here...","source":"my-doc"}'
 
 # 2) Ask (grounded in your docs — wait ~10s after ingesting)
@@ -66,6 +78,8 @@ curl -X POST https://serverless-rag-assistant.tienvo.workers.dev/ask \
   -H "content-type: application/json" \
   -d '{"question":"..."}'
 ```
+
+</details>
 
 **Highlights:**
 - **Anti-hallucination** — replies "I don't know" when the answer isn't in your documents (prompt-engineered guardrail).

--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -1,0 +1,34 @@
+# Recording the demo GIF (`docs/demo.gif`)
+
+The README embeds `docs/demo.gif`. The binary is **not** committed by the code
+change — record it once and drop the file here so the image resolves.
+
+## What the Worker serves
+
+The Worker (`src/index.js`) serves a small web UI at `/` (no build step, vanilla
+HTML/JS). It exposes:
+
+- **Ask** — example-question chips + a textarea → `POST /ask`; renders the
+  answer with its **source documents** and **similarity scores**, plus an
+  `Asking…` / `Consultando…` loading state and inline error handling.
+- **Advanced → ingest** — textarea + `source` + an `INGEST_TOKEN` field →
+  `POST /ingest`. The token is typed by the user and never stored in the page.
+
+## Suggested 15–20s capture (ingest → ask → answer)
+
+1. Open the live URL (or `npm run dev` locally).
+2. Click a preloaded example question and hit **Get answer** — show the answer
+   appearing with its **sources + similarity scores**.
+3. (Optional) Open **Advanced: ingest your own document**, paste a short text +
+   `source` + your `INGEST_TOKEN`, click **Ingest**, show the success line.
+4. Ask a question about the freshly ingested text and show the grounded answer.
+
+Keep the `INGEST_TOKEN` off-screen (or blur it) so no secret is captured.
+
+## Tools
+
+- **ScreenToGif** (Windows) or **Peek** (Linux) — record the browser region.
+- Target ~800px wide, ≤ 6 MB, loop enabled.
+- Save as `docs/demo.gif` and commit **only** the GIF.
+
+Nothing else in the repo needs to change once the GIF is in place.

--- a/src/index.js
+++ b/src/index.js
@@ -108,7 +108,7 @@ async function handleAsk(request, env) {
 
 const INDEX_HTML = `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Serverless RAG Assistant</title>
 <style>
-:root{--bg:#f5f7fa;--card:#ffffff;--ink:#0f172a;--body:#334155;--mut:#64748b;--line:#e6eaf0;--acc:#1d4ed8;--soft:#eef3ff}
+:root{--bg:#f5f7fa;--card:#ffffff;--ink:#0f172a;--body:#334155;--mut:#64748b;--line:#e6eaf0;--acc:#1d4ed8;--soft:#eef3ff;--ok:#0f766e}
 *{box-sizing:border-box}
 body{margin:0;font-family:"Segoe UI",system-ui,Arial,sans-serif;background:var(--bg);color:var(--body);display:flex;min-height:100vh;align-items:center;justify-content:center;padding:24px;line-height:1.6}
 .card{max-width:680px;width:100%;background:var(--card);border:1px solid var(--line);border-radius:14px;padding:34px;box-shadow:0 12px 44px -22px rgba(15,23,42,.20)}
@@ -122,10 +122,25 @@ h1{font-size:24px;color:var(--ink);margin:6px 0}
 .chips{display:flex;flex-wrap:wrap;gap:8px;margin-bottom:16px}
 .chip{font-size:13px;background:var(--soft);border:1px solid #dbe4ff;color:var(--acc);padding:6px 12px;border-radius:8px;cursor:pointer;transition:background .15s}
 .chip:hover{background:#e0e9ff}
-textarea{width:100%;background:#fff;border:1px solid var(--line);color:var(--ink);border-radius:10px;padding:12px;font-size:15px;resize:vertical;min-height:58px;font-family:inherit}
+textarea,input.txt{width:100%;background:#fff;border:1px solid var(--line);color:var(--ink);border-radius:10px;padding:12px;font-size:15px;resize:vertical;font-family:inherit}
+textarea{min-height:58px}
 button.ask{margin-top:10px;background:var(--acc);color:#fff;border:none;border-radius:10px;padding:11px 22px;font-weight:600;cursor:pointer;font-size:15px}
 button.ask:hover{background:#1843b8}
-.out{margin-top:16px;background:#f8fafc;border:1px solid var(--line);border-radius:10px;padding:15px;min-height:46px;font-size:15px;color:var(--ink);white-space:pre-wrap}
+button.ask:disabled{opacity:.55;cursor:progress}
+.out{margin-top:16px;background:#f8fafc;border:1px solid var(--line);border-radius:10px;padding:15px;min-height:46px;font-size:15px;color:var(--ink)}
+.out .ans{white-space:pre-wrap}
+.out .err{color:#b91c1c}
+.srcs{margin-top:12px;padding-top:11px;border-top:1px dashed var(--line);font-size:13px;color:var(--mut)}
+.srcs b{color:var(--ink);font-weight:600}
+.score{display:inline-block;font-variant-numeric:tabular-nums;background:#ecfdf5;color:var(--ok);border:1px solid #ccece4;border-radius:6px;padding:1px 7px;margin-left:6px;font-size:12px}
+details{margin-top:22px;border-top:1px solid var(--line);padding-top:16px}
+summary{cursor:pointer;font-size:13.5px;font-weight:600;color:var(--ink);list-style:none}
+summary::-webkit-details-marker{display:none}
+summary::before{content:"\\25B8 ";color:var(--mut)}
+details[open] summary::before{content:"\\25BE ";color:var(--mut)}
+.row{display:flex;gap:10px;margin-top:12px}
+.row .txt{flex:1}
+.hint{font-size:12px;color:var(--mut);margin:6px 0 0}
 .foot{margin-top:20px;padding-top:15px;border-top:1px solid var(--line);color:var(--mut);font-size:13px}
 .foot a{color:var(--acc);text-decoration:none}
 </style></head><body>
@@ -138,15 +153,65 @@ button.ask:hover{background:#1843b8}
   <p class="label" data-en="This demo is preloaded with a short profile. Select an example question:" data-es="Esta demostracion trae cargado un perfil breve. Selecciona una pregunta de ejemplo:">This demo is preloaded with a short profile. Select an example question:</p>
   <div class="chips" id="chips"></div>
   <textarea id="q"></textarea>
-  <button class="ask" onclick="ask()" data-en="Get answer" data-es="Obtener respuesta">Get answer</button>
-  <div class="out" id="out" data-en="The answer will appear here, with its source document." data-es="La respuesta aparecera aqui, con su documento fuente.">The answer will appear here, with its source document.</div>
+  <button class="ask" id="askBtn" onclick="ask()" data-en="Get answer" data-es="Obtener respuesta">Get answer</button>
+  <div class="out" id="out"><span class="ans" data-en="The answer will appear here, with its source document and similarity scores." data-es="La respuesta aparecera aqui, con su documento fuente y los puntajes de similitud.">The answer will appear here, with its source document and similarity scores.</span></div>
+
+  <details id="ing">
+    <summary data-en="Advanced: ingest your own document" data-es="Avanzado: ingiere tu propio documento">Advanced: ingest your own document</summary>
+    <p class="hint" data-en="Ingestion is token-protected. Paste your INGEST_TOKEN to teach the assistant a new document (nothing is stored in this page)." data-es="La ingesta esta protegida por token. Pega tu INGEST_TOKEN para ensenarle un documento nuevo (nada se guarda en esta pagina).">Ingestion is token-protected. Paste your INGEST_TOKEN to teach the assistant a new document (nothing is stored in this page).</p>
+    <textarea id="itext" data-en-ph="Paste document text here..." data-es-ph="Pega el texto del documento aqui..."></textarea>
+    <div class="row">
+      <input class="txt" id="isrc" data-en-ph="source name (e.g. my-doc)" data-es-ph="nombre de la fuente (ej. mi-doc)"/>
+      <input class="txt" id="itok" type="password" placeholder="INGEST_TOKEN"/>
+    </div>
+    <button class="ask" id="ingBtn" onclick="ingest()" data-en="Ingest" data-es="Ingerir">Ingest</button>
+    <div class="out" id="iout" style="display:none"></div>
+  </details>
+
   <p class="foot"><span data-en="Designed and built by Juan Berrio, Cloud &amp; Data Engineer. Source code:" data-es="Disenado y construido por Juan Berrio, Cloud &amp; Data Engineer. Codigo fuente:">Designed and built by Juan Berrio, Cloud &amp; Data Engineer. Source code:</span> <a href="https://github.com/juanberrio0399/serverless-rag-assistant" target="_blank">GitHub</a></p>
 </div>
 <script>
+var LANG="en";
 var EX={en:["How many records does DataForge process?","What technologies does DataForge use?","How often does DataForge run?"],es:["Cuantos registros procesa DataForge?","Que tecnologias usa DataForge?","Cada cuanto se ejecuta DataForge?"]};
+var T={en:{asking:"Asking...",ingesting:"Ingesting...",err:"Error: ",sources:"Sources",empty:"Type a question first.",noText:"Paste some document text first.",noTok:"Paste your INGEST_TOKEN first.",done:"Ingested "},es:{asking:"Consultando...",ingesting:"Ingiriendo...",err:"Error: ",sources:"Fuentes",empty:"Escribe una pregunta primero.",noText:"Pega el texto de un documento primero.",noTok:"Pega tu INGEST_TOKEN primero.",done:"Ingeridos "}};
+function esc(s){return String(s).replace(/[&<>]/g,function(c){return{"&":"&amp;","<":"&lt;",">":"&gt;"}[c]})}
 function chips(l){var c=document.getElementById("chips");c.innerHTML="";EX[l].forEach(function(t){var b=document.createElement("span");b.className="chip";b.textContent=t;b.onclick=function(){document.getElementById("q").value=t};c.appendChild(b)})}
-function L(l){document.documentElement.lang=l;document.querySelectorAll("[data-en]").forEach(function(e){var v=e.getAttribute("data-"+l);if(v)e.textContent=v});document.getElementById("bEN").classList.toggle("on",l==="en");document.getElementById("bES").classList.toggle("on",l==="es");chips(l);document.getElementById("q").value=EX[l][0]}
-async function ask(){var q=document.getElementById("q").value.trim(),o=document.getElementById("out");if(!q)return;o.textContent="...";try{var r=await fetch("/ask",{method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify({question:q})});var d=await r.json();o.textContent=(d.answer||d.error||"-")+(d.sources&&d.sources.length?"   ["+d.sources.join(", ")+"]":"")}catch(e){o.textContent="Error: "+e.message}}
+function L(l){LANG=l;document.documentElement.lang=l;document.querySelectorAll("[data-en]").forEach(function(e){var v=e.getAttribute("data-"+l);if(v)e.textContent=v});document.querySelectorAll("[data-en-ph]").forEach(function(e){var v=e.getAttribute("data-"+l+"-ph");if(v)e.placeholder=v});document.getElementById("bEN").classList.toggle("on",l==="en");document.getElementById("bES").classList.toggle("on",l==="es");chips(l);document.getElementById("q").value=EX[l][0]}
+async function ask(){
+  var q=document.getElementById("q").value.trim(),o=document.getElementById("out"),btn=document.getElementById("askBtn");
+  if(!q){o.innerHTML='<span class="err">'+T[LANG].empty+'</span>';return}
+  btn.disabled=true;o.innerHTML='<span class="ans">'+T[LANG].asking+'</span>';
+  try{
+    var r=await fetch("/ask",{method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify({question:q})});
+    var d=await r.json();
+    if(!r.ok||d.error){o.innerHTML='<span class="err">'+esc(d.error||("HTTP "+r.status))+'</span>';return}
+    var html='<div class="ans">'+esc(d.answer||"-")+'</div>';
+    if(d.matches&&d.matches.length){
+      html+='<div class="srcs"><b>'+T[LANG].sources+':</b> ';
+      html+=d.matches.map(function(m){return esc(m.source)+'<span class="score">'+Number(m.score).toFixed(3)+'</span>'}).join(" ");
+      html+='</div>';
+    }else if(d.sources&&d.sources.length){
+      html+='<div class="srcs"><b>'+T[LANG].sources+':</b> '+esc(d.sources.join(", "))+'</div>';
+    }
+    o.innerHTML=html;
+  }catch(e){o.innerHTML='<span class="err">'+T[LANG].err+esc(e.message)+'</span>'}
+  finally{btn.disabled=false}
+}
+async function ingest(){
+  var text=document.getElementById("itext").value.trim(),src=document.getElementById("isrc").value.trim()||"manual",tok=document.getElementById("itok").value.trim();
+  var o=document.getElementById("iout"),btn=document.getElementById("ingBtn");
+  o.style.display="block";
+  if(!text){o.innerHTML='<span class="err">'+T[LANG].noText+'</span>';return}
+  if(!tok){o.innerHTML='<span class="err">'+T[LANG].noTok+'</span>';return}
+  btn.disabled=true;o.innerHTML='<span class="ans">'+T[LANG].ingesting+'</span>';
+  try{
+    var r=await fetch("/ingest",{method:"POST",headers:{"content-type":"application/json","authorization":"Bearer "+tok},body:JSON.stringify({text:text,source:src})});
+    var d=await r.json();
+    if(!r.ok||d.error){o.innerHTML='<span class="err">'+esc(d.error||("HTTP "+r.status))+'</span>';return}
+    o.innerHTML='<span class="ans">'+T[LANG].done+d.chunks+' chunk(s) &rarr; "'+esc(d.source)+'". '+esc(d.note||"")+'</span>';
+  }catch(e){o.innerHTML='<span class="err">'+T[LANG].err+esc(e.message)+'</span>'}
+  finally{btn.disabled=false}
+}
 L("en");
 </script></body></html>`;
 


### PR DESCRIPTION
## Qué hace

Convierte la demo de "solo `curl`" en una demo visual en 1 clic, **sin backend nuevo ni dependencias**, aprovechando que el Worker ya servía una página inline en `/`.

### `src/index.js` — se enriquece la página inline (`INDEX_HTML`)
- **Preguntar (`/ask`)**: además de la respuesta y las fuentes, ahora muestra los **puntajes de similitud** por fuente, un estado de carga **"Asking… / Consultando…"** y **manejo de error inline** (mensaje en rojo, sin romper la página).
- **Panel "Advanced: ingest your own document" (`/ingest`)**: textarea + `source` + campo **INGEST_TOKEN**. El token lo **teclea el usuario** y no se almacena ni se embebe en el HTML (sin secretos en el frontend). Estado de carga y errores igual que en ask.
- La API (`POST /ingest`, `POST /ask`) queda **intacta**; solo se cambió el HTML servido en la ruta raíz.

### `README.md` / `README.es.md`
- "Live demo" ahora **encabeza con la demo del navegador** + `![demo](docs/demo.gif)`.
- El ejemplo `curl` se conserva como **referencia secundaria** (en `<details>`) y se **corrige** con el header `Authorization: Bearer` que `/ingest` realmente exige.

### `docs/DEMO.md` (nuevo)
- Guion de ~20s para grabar el GIF. **El binario `docs/demo.gif` no se incluye en este PR** (se graba y se commitea aparte); hasta entonces el enlace de imagen queda roto a propósito, como se documenta.

## Cómo probarlo localmente
1. `npm install`
2. `npm run dev` (usa `wrangler dev --remote`; requiere cuenta Cloudflare con los bindings AI/Vectorize)
3. Abre la URL local → verás la UI. Elige una pregunta de ejemplo → **Get answer**: respuesta + fuentes + scores.
4. **Advanced → Ingest**: pega un texto + `source` + tu `INGEST_TOKEN` → **Ingest**; luego pregunta sobre ese texto.

Verificación offline incluida: `node --check src/index.js` OK; el `<script>` embebido y los IDs del DOM validados; `wrangler.jsonc` sin cambios (coherente).

## Qué NO se tocó
- Lógica RAG de `/ingest` y `/ask` (solo se sirve/consume, no se cambia).
- `wrangler.jsonc` (no se añadió assets binding: no hacía falta, la página va inline).
- Infra / secretos / despliegue.

No merge — queda abierto para revisión.

Closes #11