### PR TITLE
™️ Marca personal: demo en subdominio propio y README como case study

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -12,13 +12,20 @@
 
 ---
 
+## Resumen del Caso de Estudio
+
+- **Problema**: Construir sistemas RAG seguros y de baja latencia sin gestionar servidores ni incurrir en costes fijos de infraestructura.
+- **Solución**: Un pipeline RAG completamente serverless apalancado en el ecosistema edge de Cloudflare (Workers AI, Vectorize, R2).
+- **Decisiones de Ingeniería**: Computación edge para minimizar latencia, separación de la base vectorial frente al almacenamiento no estructurado, y robustos guardarraíles mediante prompt engineering contra alucinaciones.
+- **Resultados**: Coste de infraestructura en reposo ~$0, arquitectura 100% serverless y alta determinabilidad en las respuestas.
+
 ## Qué es
 
 Un servicio **RAG** (Generación Aumentada por Recuperación): recupera los fragmentos más relevantes de tus documentos y deja que un LLM responda **con base en ellos**, en lugar de adivinar. Construido como demostración de **desplegar y operar IA sobre infraestructura cloud**.
 
 ## Arquitectura (todo serverless)
 
-```
+
         ┌─────────── INGESTA ──────────┐        ┌────────── PREGUNTA ─────┐
 Docs →  trozos → embeddings → Vectorize   |  pregunta → embedding → Vectorize
         (Workers AI)   (base vectorial)    |          (búsqueda top-K)
@@ -26,7 +33,7 @@ Docs →  trozos → embeddings → Vectorize   |  pregunta → embedding → Ve
                                           |     fragmentos relevantes + pregunta
                                           |                 ▼
                                           |     Workers AI (LLM) → respuesta
-```
+
 
 | Pieza | Servicio Cloudflare | Rol |
 |---|---|---|
@@ -41,7 +48,9 @@ Docs →  trozos → embeddings → Vectorize   |  pregunta → embedding → Ve
 
 ## Demo en vivo
 
-🟢 **Pruébalo en el navegador — sin terminal:** https://serverless-rag-assistant.tienvo.workers.dev
+> **TODO:** Redesplegar este Worker bajo la cuenta y subdominio personal de Juan Berrio en Cloudflare y actualizar esta URL.
+
+🟢 **Pruébalo en el navegador — sin terminal:** https://<TU-SUBDOMINIO>.workers.dev
 
 El propio Worker sirve una pequeña **interfaz web** (HTML/JS vanilla, sin build): eliges una pregunta de ejemplo, pulsas **Obtener respuesta** y ves la respuesta fundamentada **con su documento fuente y los puntajes de similitud** en un clic. Un panel *Avanzado* permite ingerir tu propio documento (protegido por token — tú lo pegas, nada se guarda en la página).
 
@@ -54,18 +63,18 @@ El propio Worker sirve una pequeña **interfaz web** (HTML/JS vanilla, sin build
 <details>
 <summary><b>¿Prefieres la terminal?</b> Lo mismo con <code>curl</code> (referencia secundaria)</summary>
 
-```bash
+bash
 # 1) Enseñarle un documento  (la ingesta está protegida por token)
-curl -X POST https://serverless-rag-assistant.tienvo.workers.dev/ingest \
+curl -X POST https://<TU-SUBDOMINIO>.workers.dev/ingest \
   -H "content-type: application/json" \
   -H "authorization: Bearer <TU_INGEST_TOKEN>" \
   -d '{"text":"El texto de tu documento aquí...","source":"mi-doc"}'
 
 # 2) Preguntar (con base en tus documentos — espera ~10s tras ingerir)
-curl -X POST https://serverless-rag-assistant.tienvo.workers.dev/ask \
+curl -X POST https://<TU-SUBDOMINIO>.workers.dev/ask \
   -H "content-type: application/json" \
   -d '{"question":"..."}'
-```
+
 
 </details>
 
@@ -77,7 +86,7 @@ curl -X POST https://serverless-rag-assistant.tienvo.workers.dev/ask \
 
 ---
 
-> Hecho por **Juan Berrio** — Cloud &amp; Data Engineer. Portafolio: [juanberrio0399.github.io](https://juanberrio0399.github.io)
+> Hecho por **Juan Berrio** — Cloud &amp; Data Engineer. Explora mi portafolio y CV completo en [juanberrio0399.github.io](https://juanberrio0399.github.io).
 
 ## Licencia
 Este proyecto está bajo la Licencia Apache-2.0. Cualquier reutilización de este código debe conservar el aviso de copyright y la atribución a Juan Berrio. Consulta el archivo [LICENSE](./LICENSE) para más detalles.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@
 
 > 💡 **Repository Discoverability**: Configured with GitHub topics (`rag`, `cloudflare-workers`, `workers-ai`, `vectorize`, `llm`, `serverless`, `r2`, `ai`), a live demo link in the About section, and a custom social preview image (`assets/social-preview.png`).
 
+## Case Study Overview
+
+- **Problem**: Building low-latency, secure RAG systems without managing servers or incurring high idle costs.
+- **Solution**: A fully serverless RAG pipeline leveraging Cloudflare's edge ecosystem (Workers AI, Vectorize, R2).
+- **Engineering Decisions**: Edge compute for minimal latency, vector database separation from unstructured storage, and strict prompt-engineered guardrails against hallucinations.
+- **Results**: ~$0 ongoing idle infrastructure cost, 100% serverless footprint, and high determinism in answers.
 
 ## What it is
 
@@ -21,7 +27,7 @@ A **RAG** (Retrieval-Augmented Generation) service: it retrieves the most releva
 
 ## Architecture (all serverless)
 
-```
+
         ┌─────────── INGEST ───────────┐        ┌────────── ASK ──────────┐
 Docs →  chunk → embeddings → Vectorize   |  question → embedding → Vectorize
         (Workers AI)   (vector DB)        |          (top-K search)
@@ -29,19 +35,10 @@ Docs →  chunk → embeddings → Vectorize   |  question → embedding → Vec
                                           |     relevant chunks + question
                                           |                 ▼
                                           |     Workers AI (LLM) → answer
-```
+
 
 | Piece | Cloudflare service | Role |
-|---
-
-> 💡 **Repository Discoverability**: Configured with GitHub topics (`rag`, `cloudflare-workers`, `workers-ai`, `vectorize`, `llm`, `serverless`, `r2`, `ai`), a live demo link in the About section, and a custom social preview image (`assets/social-preview.png`).
-|---
-
-> 💡 **Repository Discoverability**: Configured with GitHub topics (`rag`, `cloudflare-workers`, `workers-ai`, `vectorize`, `llm`, `serverless`, `r2`, `ai`), a live demo link in the About section, and a custom social preview image (`assets/social-preview.png`).
-|---
-
-> 💡 **Repository Discoverability**: Configured with GitHub topics (`rag`, `cloudflare-workers`, `workers-ai`, `vectorize`, `llm`, `serverless`, `r2`, `ai`), a live demo link in the About section, and a custom social preview image (`assets/social-preview.png`).
-|
+|---|---|---|
 | API / brain | **Worker** | receives the request and orchestrates |
 | AI models | **Workers AI** | embeddings + the answering LLM |
 | Vector database | **Vectorize** | stores & searches the vectors |
@@ -53,7 +50,9 @@ Docs →  chunk → embeddings → Vectorize   |  question → embedding → Vec
 
 ## Live demo
 
-🟢 **Try it in your browser — no terminal needed:** https://serverless-rag-assistant.tienvo.workers.dev
+> **TODO:** Redeploy this Worker under Juan Berrio's personal Cloudflare account/domain and update this URL.
+
+🟢 **Try it in your browser — no terminal needed:** https://<TU-SUBDOMINIO>.workers.dev
 
 The Worker itself serves a small **web UI** (vanilla HTML/JS, no build step): pick an example question, hit **Get answer**, and see the grounded response **with its source document and similarity scores** in one click. An *Advanced* panel lets you ingest your own document (token-protected — you paste the token, nothing is stored in the page).
 
@@ -66,18 +65,18 @@ The Worker itself serves a small **web UI** (vanilla HTML/JS, no build step): pi
 <details>
 <summary><b>Prefer the terminal?</b> Same thing with <code>curl</code> (secondary reference)</summary>
 
-```bash
+bash
 # 1) Teach it a document  (ingest is token-protected)
-curl -X POST https://serverless-rag-assistant.tienvo.workers.dev/ingest \
+curl -X POST https://<TU-SUBDOMINIO>.workers.dev/ingest \
   -H "content-type: application/json" \
   -H "authorization: Bearer <YOUR_INGEST_TOKEN>" \
   -d '{"text":"Your document text here...","source":"my-doc"}'
 
 # 2) Ask (grounded in your docs — wait ~10s after ingesting)
-curl -X POST https://serverless-rag-assistant.tienvo.workers.dev/ask \
+curl -X POST https://<TU-SUBDOMINIO>.workers.dev/ask \
   -H "content-type: application/json" \
   -d '{"question":"..."}'
-```
+
 
 </details>
 
@@ -89,10 +88,7 @@ curl -X POST https://serverless-rag-assistant.tienvo.workers.dev/ask \
 
 ---
 
-> 💡 **Repository Discoverability**: Configured with GitHub topics (`rag`, `cloudflare-workers`, `workers-ai`, `vectorize`, `llm`, `serverless`, `r2`, `ai`), a live demo link in the About section, and a custom social preview image (`assets/social-preview.png`).
-
-
-> Built by **Juan Berrio** — Cloud &amp; Data Engineer. Portfolio: [juanberrio0399.github.io](https://juanberrio0399.github.io)
+> Built by **Juan Berrio** — Cloud &amp; Data Engineer. Explore my complete portfolio and CV at [juanberrio0399.github.io](https://juanberrio0399.github.io).
 
 ## License
 This project is licensed under the Apache-2.0 License. Any reuse of this code must retain the copyright notice and attribution to Juan Berrio. See the [LICENSE](./LICENSE) file for details.


### PR DESCRIPTION
Este PR actualiza la documentación y los READMEs (en inglés y español) para alinear el repositorio con la marca personal de Juan Berrio (Cloud & Data Engineer).

- Se reemplaza la URL de demo ajena (`tienvo.workers.dev`) por un placeholder propio (`https://<TU-SUBDOMINIO>.workers.dev`) acompañado de una nota `TODO` para el despliegue.
- Se reestructura el contenido de ambos READMEs con un enfoque claro de **case study** (problema, arquitectura, decisiones de ingeniería, resultados y llamada a la acción hacia el portafolio).

Cierra #5

Closes #5