### PR TITLE
🎓 Certificaciones vigentes: Terraform Associate 004 + Cloudflare Learning Paths

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -46,6 +46,8 @@ Docs →  trozos → embeddings → Vectorize   |  pregunta → embedding → Ve
 
 `Cloudflare Workers` · `Workers AI` · `Vectorize` · `R2` · `RAG` · `Integración de LLM` · `embeddings` · `Infraestructura como código (wrangler)` · `serverless` · `CI/CD`
 
+- **IaC & Cloud:** Terraform (alineado con HashiCorp Terraform Associate 004), Cloudflare Developer Platform (Rutas de aprendizaje Workers/AI), Vectorize, R2.
+
 ## Demo en vivo
 
 > **TODO:** Redesplegar este Worker bajo la cuenta y subdominio personal de Juan Berrio en Cloudflare y actualizar esta URL.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Docs →  chunk → embeddings → Vectorize   |  question → embedding → Vec
 
 `Cloudflare Workers` · `Workers AI` · `Vectorize` · `R2` · `RAG` · `LLM integration` · `embeddings` · `Infrastructure as Code (wrangler)` · `serverless` · `CI/CD`
 
+- **IaC & Cloud:** Terraform (aligned with HashiCorp Terraform Associate 004), Cloudflare Developer Platform (Workers/AI Learning Paths), Vectorize, R2.
+
 ## Live demo
 
 > **TODO:** Redeploy this Worker under Juan Berrio's personal Cloudflare account/domain and update this URL.


### PR DESCRIPTION
Este PR agrega una nota discreta en los archivos `README.md` y `README.es.md` para conectar el stack técnico de este repositorio (Terraform + Cloudflare Workers/AI) con las competencias demostradas que respaldan las certificaciones vigentes correspondientes (HashiCorp Terraform Associate 004 y Cloudflare Developer Platform Learning Paths).

Cierra #6

Closes #6