### PR TITLE
⭐ Evaluar Cloudflare AI Search (ex-AutoRAG): RAG gestionado como segunda variante

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -23,6 +23,15 @@
 
 Un servicio **RAG** (Generación Aumentada por Recuperación): recupera los fragmentos más relevantes de tus documentos y deja que un LLM responda **con base en ellos**, en lugar de adivinar. Construido como demostración de **desplegar y operar IA sobre infraestructura cloud**.
 
+## RAG Manual vs AI Search (Gestionado)
+
+| Característica | Pipeline Manual (`src/index.js`) | Cloudflare AI Search (Gestionado) |
+|---|---|---|
+| **Chunking y Embeddings** | Manual (Workers AI) | Automático en R2 |
+| **Recuperación (Retrieval)** | Vectorize puro | Búsqueda Híbrida (Vector + BM25) |
+| **Reranking y Pipeline** | Lógica en código | Gestionado nativamente |
+| **Propósito** | Demostración y portafolio | Producción ágil / Bajo mantenimiento |
+
 ## Arquitectura (todo serverless)
 
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@
 
 A **RAG** (Retrieval-Augmented Generation) service: it retrieves the most relevant pieces of your documents and lets an LLM answer **based on them** — instead of guessing. Built as a demonstration of **deploying and operating AI on cloud infrastructure**.
 
+## Manual RAG vs AI Search (Managed)
+
+| Característica | Pipeline Manual (`src/index.js`) | Cloudflare AI Search (Gestionado) |
+|---|---|---|
+| **Chunking & Embeddings** | Hecho a mano (Workers AI) | Automático sobre R2 |
+| **Retrieval** | Vectorize (Búsqueda vectorial pura) | Búsqueda Híbrida (Vector + BM25) |
+| **Reranking & Pipeline** | Lógica propia en código | Gestionado nativamente |
+| **Valor / Uso** | Demostración didáctica / Portafolio | Producción rápida / Menos mantenimiento |
+
 ## Architecture (all serverless)
 
 

--- a/docs/ai-search.md
+++ b/docs/ai-search.md
@@ -1,0 +1,41 @@
+# Cloudflare AI Search (Managed RAG) Variant
+
+Cloudflare AI Search (anteriormente conocido como AutoRAG) proporciona un pipeline RAG **totalmente gestionado** sobre Cloudflare R2 y Vectorize. A diferencia del pipeline manual de este repositorio (`src/index.js`), AI Search maneja automáticamente:
+
+- Chunking de documentos
+- Generación de embeddings
+- Re-indexado continuo al actualizar objetos en R2
+- Búsqueda híbrida (Vectorial + BM25)
+- Reranking y generación con system prompts
+
+## Configuración sobre el Bucket Existente
+
+Apuntando a nuestro bucket R2 existente (`rag-source-docs` definido en `terraform/main.tf`):
+
+1. **Habilitar AI Search / AutoRAG** en el panel de Cloudflare vinculando el bucket R2 `rag-source-docs`.
+2. **Binding en Workers (`wrangler.jsonc`)**:
+   
+   {
+     "ai_search": [
+       {
+         "binding": "AI_SEARCH",
+         "bucket": "rag-source-docs"
+       }
+     ]
+   }
+   
+3. **Consulta desde un Worker**:
+   javascript
+   export default {
+     async fetch(request, env) {
+       const url = new URL(request.url);
+       const query = url.searchParams.get("q") || "¿Qué es este repo?";
+       const results = await env.AI_SEARCH.query(query);
+       return Response.json(results);
+     }
+   };
+   
+
+## Referencias Oficiales
+- [Cloudflare AI Search Docs](https://developers.cloudflare.com/ai-search/)
+- [Release Notes](https://developers.cloudflare.com/ai-search/platform/release-note/)


### PR DESCRIPTION
Implementa la evaluación de Cloudflare AI Search (ex-AutoRAG) como una segunda variante gestionada sobre el bucket R2 existente, sin alterar ni eliminar el pipeline RAG manual.

### Cambios:
- Se crea `docs/ai-search.md` detallando la configuración y uso de Cloudflare AI Search apuntando al bucket `rag-source-docs`.
- Se actualiza `README.md` y `README.es.md` incorporando una sección comparativa ("Manual RAG vs AI Search (managed)") para destacar las diferencias en arquitectura, mantenimiento y capacidades.

Cierra #3.

Closes #3