### PR TITLE
Mejorar retrieval: chunk overlap + reranking (bge-reranker-base) + modelos vigentes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,16 +5,33 @@
 //   POST /ingest   → { text, source } : chunk → embed → store in Vectorize
 //   POST /ask      → { question }      : retrieve relevant chunks → LLM answer  (Module 4)
 
+// --- Models (Workers AI) --------------------------------------------------
+// Defaults kept intentionally: changing EMBED_MODEL alters the vector
+// dimension and REQUIRES a full re-ingest of the Vectorize index, so it is
+// documented here, not switched. Current alternatives worth an A/B test:
+//   LLM:        @cf/zai-org/glm-4.7-flash (fast tool-calling),
+//               @cf/openai/gpt-oss-20b (low latency) / -120b (production)
+//   Embeddings: @cf/google/embeddinggemma-300m (recent, stronger)
+//               ^ swapping this needs a re-ingest (different dimension/index).
 const EMBED_MODEL = "@cf/baai/bge-base-en-v1.5";      // 768-dim embeddings
 const LLM_MODEL = "@cf/meta/llama-3.2-3b-instruct";   // answering model (current, multilingual)
+const RERANK_MODEL = "@cf/baai/bge-reranker-base";    // cross-encoder reranker (query↔chunk relevance)
 const CHUNK_SIZE = 800;                                // characters per chunk
+const CHUNK_OVERLAP = 120;                             // chars shared between consecutive chunks (~15%): keeps context across borders, improves recall
+const MIN_RERANK_SCORE = 0.4;                          // drop weakly-relevant chunks after reranking
 
-// Split raw text into fixed-size chunks (small enough for good retrieval).
-function chunkText(text, size = CHUNK_SIZE) {
+// Split raw text into overlapping chunks. Overlap keeps sentences that fall on
+// a chunk boundary retrievable from both sides (better recall). The step is
+// `size - overlap`; it is clamped to >= 1 so a mis-set overlap can't loop forever.
+function chunkText(text, size = CHUNK_SIZE, overlap = CHUNK_OVERLAP) {
   const clean = text.replace(/\s+/g, " ").trim();
+  if (!clean) return [];
+  if (clean.length <= size) return [clean];
+  const step = Math.max(1, size - overlap);
   const chunks = [];
-  for (let i = 0; i < clean.length; i += size) {
+  for (let i = 0; i < clean.length; i += step) {
     chunks.push(clean.slice(i, i + size));
+    if (i + size >= clean.length) break; // last window already reached the end
   }
   return chunks;
 }
@@ -82,8 +99,38 @@ async function handleAsk(request, env) {
     return json({ answer: "No documents ingested yet — add some with /ingest first.", sources: [] });
   }
 
-  // 3) Build the context block from the retrieved chunks
-  const context = matches.map((m, i) => `[${i + 1}] ${m.metadata.text}`).join("\n\n");
+  // 2b) Rerank the retrieved chunks with a cross-encoder for true query↔chunk
+  //     relevance (Vectorize gives approximate vector similarity; the reranker
+  //     scores the pair directly and re-orders, lifting precision on noisy corpora).
+  //     Verified output shape (Cloudflare workers-types Ai_Cf_Baai_Bge_Reranker_Base_Output):
+  //       { response: [ { id, score } ] }
+  //     where `id` is the INDEX into the `contexts` we sent and `score` is the
+  //     relevance score. We map each id back to its match and sort by score desc.
+  let ordered = matches;
+  try {
+    const rr = await env.AI.run(RERANK_MODEL, {
+      query: question,
+      contexts: matches.map((m) => ({ text: m.metadata.text })),
+    });
+    const ranking = rr?.response;
+    if (Array.isArray(ranking) && ranking.length) {
+      const reranked = ranking
+        .filter((r) => r && typeof r.id === "number" && matches[r.id])
+        .map((r) => ({ ...matches[r.id], rerankScore: r.score }))
+        .sort((a, b) => (b.rerankScore ?? 0) - (a.rerankScore ?? 0));
+      if (reranked.length) {
+        const kept = reranked.filter((m) => (m.rerankScore ?? 0) >= MIN_RERANK_SCORE);
+        // Keep at least the top match even if all scores fall below the threshold.
+        ordered = kept.length ? kept : [reranked[0]];
+      }
+    }
+  } catch (err) {
+    // Reranker unavailable → fall back to the original Vectorize similarity order.
+    ordered = matches;
+  }
+
+  // 3) Build the context block from the reranked chunks
+  const context = ordered.map((m, i) => `[${i + 1}] ${m.metadata.text}`).join("\n\n");
 
   // 4) Prompt engineering: force the model to answer ONLY from the context
   const messages = [
@@ -101,8 +148,9 @@ async function handleAsk(request, env) {
 
   return json({
     answer: ai.response,
-    sources: [...new Set(matches.map((m) => m.metadata.source))],
-    matches: matches.map((m) => ({ score: m.score, source: m.metadata.source })),
+    sources: [...new Set(ordered.map((m) => m.metadata.source))],
+    // score = reranker relevance when reranking succeeded, else the vector similarity.
+    matches: ordered.map((m) => ({ score: m.rerankScore ?? m.score, source: m.metadata.source })),
   });
 }
 


### PR DESCRIPTION
Re-implementación limpia del issue #4 (el intento previo, PR #17, no se usó). Cambios **solo en `src/index.js`**, únicamente el retrieval. **No se toca el demo/HTML del #16** ni los contratos JSON de `/ingest` y `/ask`.

## Qué cambié

**1. Chunk overlap (`chunkText`)**
- Nueva constante `CHUNK_OVERLAP = 120` (~15% de `CHUNK_SIZE=800`).
- El bucle avanza `step = size - overlap`, con `step` clamped a `>= 1` para que un overlap mal configurado no cuelgue el proceso (sin loop infinito). Los chunks consecutivos comparten 120 chars, así una frase que cae en un borde sigue siendo recuperable desde ambos lados → mejor recall.

**2. Reranking con `@cf/baai/bge-reranker-base` (`handleAsk`)**
- Tras la consulta a Vectorize se llama al cross-encoder con `{ query, contexts: matches.map(m => ({ text: m.metadata.text })) }`.
- Se reordenan los matches por el `score` real query↔chunk (desc), se filtra por `MIN_RERANK_SCORE = 0.4` con guardia de **no vaciar** (si todo cae bajo el umbral, se conserva el mejor match).
- Todo envuelto en `try/catch` con **fallback** al orden de similitud vectorial original si el reranker falla. En el camino feliz **sí reordena** (no es no-op).
- El contexto del LLM y la salida (`sources`, `matches`) se construyen desde el arreglo reordenado; `matches[].score` muestra el score del reranker cuando aplica, o el vectorial en el fallback.

**3. Modelos vigentes (solo documentado)**
- Comentario con alternativas de Workers AI: LLM `@cf/zai-org/glm-4.7-flash`, `@cf/openai/gpt-oss-20b`/`-120b`; embeddings `@cf/google/embeddinggemma-300m`. **No** se cambian los defaults (`bge-base-en-v1.5` + `llama-3.2-3b-instruct`): cambiar embeddings obliga a re-ingesta (cambia dimensión/índice), así que queda anotado, no forzado.

## Forma de respuesta del reranker (VERIFICADA)

El intento anterior asumió `{ data: [{ index, score }] }`, que es **incorrecto**. La forma real es:

```
{ response: [ { id, score } ] }
```

donde `id` es el **índice** del contexto que se envió (no un id arbitrario) y `score` es la relevancia. Verificado contra los tipos oficiales `Ai_Cf_Baai_Bge_Reranker_Base_Output` en `cloudflare/workerd`:

- https://developers.cloudflare.com/workers-ai/models/bge-reranker-base/ (la salida se documenta como `response[]`)
- `cloudflare/workerd` types (`Ai_Cf_Baai_Bge_Reranker_Base_Output`): `response?: { id?: number; score?: number }[]` — el comentario del tipo dice literalmente "Index of the context in the request" para `id`.

El código mapea `response[].id` → `matches[id]` y ordena desc por `score`.

## Validación
- `node --check src/index.js` → OK.
- Archivos tocados: **`src/index.js`** (único).

Closes #4