### PR TITLE
Fix: activar de verdad el rate limiting de /ask (wrangler mal configurado)

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -15,10 +15,10 @@
     { "binding": "VECTORIZE", "index_name": "rag-index" }
   ],
 
-  // Rate limiting binding para proteger /ask
-  "rate_limiting": [
+  // Rate limiting binding para proteger /ask (clave correcta: "ratelimits" + "name", segun la doc de Cloudflare)
+  "ratelimits": [
     {
-      "binding": "RATE_LIMITER",
+      "name": "RATE_LIMITER",
       "namespace_id": "1001",
       "simple": { "limit": 10, "period": 60 }
     }


### PR DESCRIPTION
El rate limiting de `/ask` (que vino del #8) estaba **configurado mal** y por eso **no aplicaba**: el binding usaba la clave `rate_limiting` con `binding:`, que Cloudflare NO reconoce -> el binding no se creaba -> `env.RATE_LIMITER` = undefined -> el guard lo saltaba en silencio. La [doc oficial](https://developers.cloudflare.com/workers/runtime-apis/bindings/rate-limit/) usa la clave top-level `ratelimits` con `name`. Corregido. El codigo de `handleAsk` ya estaba bien (usa `cf-connecting-ip`, 429). Al mergear + desplegar, el limite de 10 req/60s por IP SI se aplica. Solo toca `wrangler.jsonc`.