### PR TITLE
feat(ask): rate limiting + cross-encoder reranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,15 @@ A **RAG** (Retrieval-Augmented Generation) service: it retrieves the most releva
 Docs →  chunk → embeddings → Vectorize   |  question → embedding → Vectorize
         (Workers AI)   (vector DB)        |          (top-K search)
                                           |                 │
-                                          |     relevant chunks + question
+                                          |     candidate chunks → reranker
+                                          |          (cross-encoder, precision)
                                           |                 ▼
                                           |     Workers AI (LLM) → answer
 ```
+
+The **ASK** path is rate-limited per client IP (native Cloudflare rate limiting, no
+extra storage) and over-retrieves candidates that a **cross-encoder reranker**
+(`bge-reranker-base`) re-scores for true query↔chunk relevance before the LLM answers.
 
 | Piece | Cloudflare service | Role |
 |---|---|---|
@@ -37,7 +42,7 @@ Docs →  chunk → embeddings → Vectorize   |  question → embedding → Vec
 
 ## Tech / skills demonstrated
 
-`Cloudflare Workers` · `Workers AI` · `Vectorize` · `R2` · `RAG` · `LLM integration` · `embeddings` · `Infrastructure as Code (wrangler)` · `serverless` · `CI/CD`
+`Cloudflare Workers` · `Workers AI` · `Vectorize` · `R2` · `RAG` · `reranking (cross-encoder)` · `rate limiting` · `LLM integration` · `embeddings` · `Infrastructure as Code (wrangler)` · `serverless` · `CI/CD`
 
 ## Live demo
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,8 @@
 
 const EMBED_MODEL = "@cf/baai/bge-base-en-v1.5";      // 768-dim embeddings
 const LLM_MODEL = "@cf/meta/llama-3.1-8b-instruct";   // answering model (supports tool use)
+const RERANK_MODEL = "@cf/baai/bge-reranker-base";    // cross-encoder reranker (query↔chunk relevance)
+const MIN_RERANK_SCORE = 0.4;                          // drop weakly-relevant chunks after reranking
 
 // aiAnswer — Workers AI (free) with a Groq fallback (free, GROQ_API_KEY Worker secret) for quota resilience.
 async function aiAnswer(env, messages) {
@@ -84,21 +86,63 @@ async function handleIngest(request, env) {
 
 // POST /ask  — answer a question grounded ONLY in the ingested documents
 async function handleAsk(request, env) {
+  // 0) Rate limit /ask per client IP (protects free Workers AI quota from abuse).
+  //    Optional binding: when RATE_LIMITER isn't configured the endpoint stays open.
+  if (env.RATE_LIMITER) {
+    const ip = request.headers.get("cf-connecting-ip") || "anonymous";
+    const { success } = await env.RATE_LIMITER.limit({ key: ip });
+    if (!success) {
+      return json({ error: "Rate limit exceeded. Please try again later." }, 429);
+    }
+  }
+
   const { question, topK = 5 } = await request.json().catch(() => ({}));
   if (!question) return json({ error: "Missing 'question' in body." }, 400);
 
   // 1) Embed the question with the SAME model used at ingestion
   const { data } = await env.AI.run(EMBED_MODEL, { text: [question] });
 
-  // 2) Retrieve the most similar chunks (semantic search)
-  const results = await env.VECTORIZE.query(data[0], { topK, returnMetadata: "all" });
+  // 2) Retrieve a WIDER candidate pool than we finally use. Reranking only helps
+  //    when it has extra candidates to promote/demote, so we over-retrieve here
+  //    and let the cross-encoder in step 2b narrow it back down to the best ones.
+  const candidateK = Math.max(topK * 3, 12);
+  const results = await env.VECTORIZE.query(data[0], { topK: candidateK, returnMetadata: "all" });
   const matches = results.matches ?? [];
   if (matches.length === 0) {
     return json({ answer: "No documents ingested yet — add some with /ingest first.", sources: [] });
   }
 
-  // 3) Build the context block from the retrieved chunks
-  const context = matches.map((m, i) => `[${i + 1}] ${m.metadata.text}`).join("\n\n");
+  // 2b) Rerank the candidates with a cross-encoder for true query↔chunk relevance
+  //     (Vectorize gives approximate vector similarity; the reranker scores the
+  //     pair directly and re-orders, lifting precision on noisy corpora).
+  //     Output shape: { response: [ { id, score } ] } where `id` indexes into the
+  //     contexts we sent. We map each id back to its match and sort by score desc,
+  //     drop weakly-relevant chunks, and keep at most topK.
+  let ordered = matches;
+  try {
+    const rr = await env.AI.run(RERANK_MODEL, {
+      query: question,
+      contexts: matches.map((m) => ({ text: m.metadata.text })),
+    });
+    const ranking = rr?.response;
+    if (Array.isArray(ranking) && ranking.length) {
+      const reranked = ranking
+        .filter((r) => r && typeof r.id === "number" && matches[r.id])
+        .map((r) => ({ ...matches[r.id], rerankScore: r.score }))
+        .sort((a, b) => (b.rerankScore ?? 0) - (a.rerankScore ?? 0));
+      if (reranked.length) {
+        const kept = reranked.filter((m) => (m.rerankScore ?? 0) >= MIN_RERANK_SCORE);
+        // Keep at least the top match even if all scores fall below the threshold.
+        ordered = (kept.length ? kept : [reranked[0]]).slice(0, topK);
+      }
+    }
+  } catch (err) {
+    // Reranker unavailable → fall back to the original Vectorize similarity order.
+    ordered = matches.slice(0, topK);
+  }
+
+  // 3) Build the context block from the reranked chunks
+  const context = ordered.map((m, i) => `[${i + 1}] ${m.metadata.text}`).join("\n\n");
 
   // 4) Prompt engineering: force the model to answer ONLY from the context
   const messages = [
@@ -116,8 +160,8 @@ async function handleAsk(request, env) {
 
   return json({
     answer,
-    sources: [...new Set(matches.map((m) => m.metadata.source))],
-    matches: matches.map((m) => ({ score: m.score, source: m.metadata.source })),
+    sources: [...new Set(ordered.map((m) => m.metadata.source))],
+    matches: ordered.map((m) => ({ score: m.score, rerankScore: m.rerankScore, source: m.metadata.source })),
   });
 }
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -13,6 +13,16 @@
   // Binding a la base vectorial (Vectorize) → env.VECTORIZE
   "vectorize": [
     { "binding": "VECTORIZE", "index_name": "rag-index" }
+  ],
+
+  // Rate limiting nativo de Cloudflare (gratis, sin KV) para proteger /ask del abuso.
+  // Dentro del código lo usas como env.RATE_LIMITER. 20 peticiones cada 60s por IP.
+  "ratelimits": [
+    {
+      "name": "RATE_LIMITER",
+      "namespace_id": "1001",
+      "simple": { "limit": 20, "period": 60 }
+    }
   ]
 
   // (Más adelante agregamos R2 aquí para guardar los documentos originales.)


### PR DESCRIPTION
## Qué

Dos mejoras en el endpoint `/ask`:

1. **Rate limiting por IP** — rate limiting nativo de Cloudflare (`env.RATE_LIMITER`, 20 req/60s), sin KV ni almacenamiento extra. Protege la cuota gratis de Workers AI del abuso. Binding opcional: si no está configurado, el endpoint sigue abierto.
2. **Reranking con cross-encoder** — sobre-recupera candidatos de Vectorize y los reordena con `bge-reranker-base` para relevancia real query↔chunk, descartando chunks débiles (< 0.4) antes de armar el contexto del LLM. Fallback seguro al orden por similitud si el reranker falla.

## Por qué

Vectorize da similitud vectorial aproximada; el cross-encoder puntúa el par directamente y sube la precisión en corpus ruidosos. El rate limit evita que un abuso agote la cuota gratuita.

## Notas de despliegue

El binding `ratelimits` ya queda declarado en `wrangler.jsonc`. Al hacer `wrangler deploy` se aplica solo (no requiere crear recursos a mano).